### PR TITLE
refactor: update splash, icon, websites for 2018

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-.idea/*
 node_modules/
 platforms/
 plugins/
@@ -7,4 +6,5 @@ my-release-key.keystore
 NorthStarConf.apk
 north-star-conf.keystore
 push-notification-certs/
+*.idea/
 

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -169,14 +169,3 @@ div.spinner {
     width: 100%;
     vertical-align: middle;
 }
-
-.tab-nav {
-  margin-bottom: 15px;
-  background-color: #00367b;
-}
-
-
-/*.bar-footer {*/
-  /*margin-bottom: env(safe-area-inset-bottom);*/
-  /*background-color: #00367b;*/
-/*}*/

--- a/www/templates/other.html
+++ b/www/templates/other.html
@@ -11,7 +11,7 @@
 
         <div class="col text-center">
           <a href="#"
-             onclick="window.open('http://conference.northstarlds.org/conference-audio/', '_system', 'location=no'); return false;">
+             onclick="window.open('https://vimeo.com/ondemand/northstar2018', '_system', 'location=no'); return false;">
             <button class="button button-large button-positive"><i class="icon ion-ios-musical-notes"></i></button>
           </a>
           <div class="positive">Conference Audio</div>
@@ -19,7 +19,7 @@
 
         <div class="col text-center">
           <a href="#"
-             onclick="window.open('http://northstarlds.org/donate/', '_system', 'location=no'); return false;">
+             onclick="window.open('https://northstarlds.org/give/donate-app/', '_system', 'location=no'); return false;">
             <button class="button button-large button-positive"><i class="icon ion-social-usd"></i></button>
           </a>
           <div class="positive">Donate</div>
@@ -52,7 +52,7 @@
 
         <div class="col text-center">
           <a href="#"
-             onclick="window.open('http://conference.northstarlds.org', '_system', 'location=no'); return false;">
+             onclick="window.open('https://northstarlds.org/conference/', '_system', 'location=no'); return false;">
             <button class="button button-large button-positive"><i class="icon ion-compass"></i></button>
           </a>
           <div class="positive">Website</div>


### PR DESCRIPTION
Update the session detail to trigger map modal without switching to ui.other.
Remove mentor, and question tiles in other tab